### PR TITLE
Use ansible provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ansible-opennms

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Usage
 
-* load submodule
-* make sure AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY is set
-* run `packer build .` to create the AMI
+* Add `ansible-opennms` submodule: `git submodule update --init`
+* Change `AMI`, `region`, or `instance_type` in `variables.pkr.hcl` if required
+* Make sure `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY` is set
+* Run `packer build .` to create the AMI

--- a/onms.pkr.hcl
+++ b/onms.pkr.hcl
@@ -32,13 +32,23 @@ build {
     expect_disconnect = true
     scripts = ["./scripts/10-update.sh", "./scripts/20-ansible.sh"]
   }
-
   sources = ["source.amazon-ebs.aws"]
 
-  provisioner "ansible" {
-        command = "ansible-playbook"
-        playbook_file = "./ansible-opennms/hzn-core-db-deployment.yml"
-        user = "ubuntu"
-        use_proxy = false
-    }
+  provisioner "ansible-local" {
+    playbook_file = "./ansible-opennms/hzn-core-db-deployment.yml"
+    extra_arguments = ["-e", "skip_startup=true" ]
+    role_paths = [
+      "ansible-opennms/roles/opennms_core",
+      "ansible-opennms/roles/opennms_icmp",
+      "ansible-opennms/roles/opennms_minion",
+      "ansible-opennms/roles/opennms_openjdk",
+      "ansible-opennms/roles/opennms_repositories",
+      "ansible-opennms/roles/opennms_sentinel",
+      "ansible-opennms/roles/stub_elasticsearch",
+      "ansible-opennms/roles/stub_grafana",
+      "ansible-opennms/roles/stub_mimir",
+      "ansible-opennms/roles/stub_kafka",
+      "ansible-opennms/roles/stub_pgsql"
+    ]
+  }
 }

--- a/onms.pkr.hcl
+++ b/onms.pkr.hcl
@@ -32,31 +32,13 @@ build {
     expect_disconnect = true
     scripts = ["./scripts/10-update.sh", "./scripts/20-ansible.sh"]
   }
-  sources = ["source.amazon-ebs.aws"]
-  provisioner "file" {
-    destination = "/home/ubuntu/"
-    source      = "./ansible-opennms"
-  }
-  provisioner "shell" {
-    environment_vars = [
-      "DEBIAN_FRONTEND=noninteractive",
-      "HOME_DIR=/home/ubuntu"
-    ]
-    execute_command   = "echo 'ubuntu' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'"
-    expect_disconnect = true
-    script = "./scripts/30-opennms.sh"
-  }
-#  provisioner "ansible" {
-#    extra_arguments = [
-#       "--connection=local",
-#       "--inventory=127.0.0.1,",
-#       "--become",
-#       "--extra-vars",
-#       "ansible_python_interpreter=/usr/bin/python"
-#      ]
-#        command = "ansible-playbook"
-#        playbook_file = "./ansible-opennms/hzn-core-db-deployment.yml"
-#        user = "ubuntu"
-#    }
 
+  sources = ["source.amazon-ebs.aws"]
+
+  provisioner "ansible" {
+        command = "ansible-playbook"
+        playbook_file = "./ansible-opennms/hzn-core-db-deployment.yml"
+        user = "ubuntu"
+        use_proxy = false
+    }
 }


### PR DESCRIPTION
Trying here the `ansible-provisioner` way instead of copying the Ansible files into the VM and running it locally. This seems to be the most clean way.

But right now I am running into this issue:
```
    amazon-ebs.aws: TASK [stub_pgsql : Set SCRAM-SHA-256 password encryption] **********************
    amazon-ebs.aws: fatal: [default]: FAILED! => {"msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chmod: invalid mode: 'A+user:postgres:rx:allow'\nTry 'chmod --help' for more information.\n}). For information on working around this, see https://docs.ansible.com/ansible-core/2.15/playbook_guide/playbooks_privilege_escalation.html#risks-of-becoming-an-unprivileged-user#risks-of-becoming-an-unprivileged-user"}

```

It looks like the ` become_user: postgres` in the `stub_pgsql` roles is causing this.
I guess the `ubuntu` user that we use is not allowed to become `postgres`. But running the provisioner as `root` is also not possible. Then we run into sudo password issues:

```
    amazon-ebs.aws: PLAY [Run a Core and PostgreSQL deployment in a local run] *********************
    amazon-ebs.aws:
    amazon-ebs.aws: TASK [Gathering Facts] *********************************************************
    amazon-ebs.aws: fatal: [default]: FAILED! => {"ansible_facts": {}, "changed": false, "failed_modules": {"ansible.legacy.setup": {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "failed": true, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}}, "msg": "The following modules failed to execute: ansible.legacy.setup\n"}
```

But how does it work in the current code state?
We connect also with `ubuntu` specified [here](https://github.com/opennms-forge/packer-ami-opennms/blob/main/variables.pkr.hcl#L28) to the VM and simply run the `ansible-playbook` command manually like [this](https://github.com/opennms-forge/packer-ami-opennms/blob/main/scripts/30-opennms.sh#L4).

