### PR TITLE
submodule wasn't working

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ansible-opennms"]
 	path = ansible-opennms
-	url = git@github.com:opennms-forge/ansible-opennms.git
+	url = https://github.com/opennms-forge/ansible-opennms.git


### PR DESCRIPTION
I had to add the subdir and redo it with the https because my keys aren't on the repo/org. Here were my various attempts to get the submodule --
```
> git submodule update --init
> git submodule update --init ansible-opennms
error: pathspec 'ansible-opennms' did not match any file(s) known to git
> git submodule init
ls -l
total 96
-rw-r--r--@ 1 mhuot  staff  35149 Jul 30 11:15 LICENSE
-rw-r--r--@ 1 mhuot  staff    259 Jul 30 11:15 README.md
-rw-r--r--@ 1 mhuot  staff   1704 Jul 30 11:15 onms.pkr.hcl
drwxr-xr-x@ 5 mhuot  staff    160 Jul 30 11:15 scripts
-rw-r--r--@ 1 mhuot  staff    540 Jul 30 11:15 variables.pkr.hcl
> cat .gitmodules
[submodule "ansible-opennms"]
	path = ansible-opennms
	url = git@github.com:opennms-forge/ansible-opennms.git
> git status
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
> mkdir ansible-opennms
> git submodule update --init ansible-opennms
error: pathspec 'ansible-opennms' did not match any file(s) known to git
> git submodule update --init
> ls -l ansible-opennms
total 0
>
```
Here is the error when using SSH --
```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:opennms-forge/ansible-opennms.git' into submodule path '/Users/mhuot/packer-ami-opennms/ansible-opennms' failed
```
